### PR TITLE
Enable tests for Python 3.8

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ['3.6', '3.7']
+        pythonversion: ['3.6', '3.7', '3.8']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ran tests on Python 3.8 successfully after tools depepdencies were upgraded. Adding it back to GitHub Actions.
